### PR TITLE
Adding unzip dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $JMETER_HOME/bin:$PATH
 # INSTALL PRE-REQ
 RUN apt-get update && \
     apt-get -y install \
-    wget 
+    wget unzip
 
 # INSTALL JMETER BASE 
 RUN mkdir /jmeter


### PR DESCRIPTION
Failed when building in **version "5.0"** is missing the unzip dependency.

![Screen_Shot_2020-05-30_at_3_44_31_PM](https://user-images.githubusercontent.com/1026153/83336941-c8badf80-a28d-11ea-9234-f5ce81612bc1.png)

![Screen_Shot_2020-05-30_at_3_44_31_PM](https://user-images.githubusercontent.com/1026153/83336967-ef791600-a28d-11ea-917c-da33813d8c47.png)

