### PR TITLE
K8S - Add data volume for distributing test data and configmap for user-properties

### DIFF
--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Distributed JMeter Helm chart
 name: distributed-jmeter
-version: 0.1.0
+version: 0.1.1
 home: http://jmeter.apache.org/
 icon: http://jmeter.apache.org/images/logo.svg
 sources:

--- a/k8s/templates/NOTES.txt
+++ b/k8s/templates/NOTES.txt
@@ -3,14 +3,15 @@ JMeter is now starting.
 
 To get get a shell session on the master you only need to run:
 
-$ export MASTER_NAME=$(kubectl get pods -l role=master -o jsonpath='{.items[*].metadata.name}')
-$ kubectl exec -it $MASTER_NAME -- /bin/bash
+$ export MASTER_NAME=$(kubectl get pods -l role=master --namespace {{ .Release.Namespace }} -o jsonpath='{.items[*].metadata.name}')
+$ kubectl exec -it $MASTER_NAME --namespace {{ .Release.Namespace }} -- /bin/bash
 
 
-To copy your test plans to the master pod:
-$ kubectl cp sample.jmx $MASTER_NAME:/jmeter
+To copy your test plans & data to the master pod:
+$ kubectl cp sample.jmx $MASTER_NAME:/jmeter/data --namespace {{ .Release.Namespace }}
+$ kubectl cp sample.csv $MASTER_NAME:/jmeter/data --namespace {{ .Release.Namespace }}
 
 
 To run your test in all servers you need first a list of all servers IPs (comma-separated) and then you can run your test:
-$ export SERVER_IPS=$(kubectl get pods -lrole=server -o jsonpath='{.items[*].status.podIP}' | tr ' ' ',')
-$ kubectl exec -it $MASTER_NAME -- jmeter -n -t /jmeter/sample.jmx -R $SERVER_IPS
+$ export SERVER_IPS=$(kubectl get pods -l role=server --namespace {{ .Release.Namespace }} -o jsonpath='{.items[*].status.podIP}' | tr ' ' ',')
+$ kubectl exec -it $MASTER_NAME --namespace {{ .Release.Namespace }} -- jmeter -n -t /jmeter/sample.jmx -R $SERVER_IPS

--- a/k8s/templates/jmeter-data-volume.yaml
+++ b/k8s/templates/jmeter-data-volume.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.dataVolume.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-data
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.dataVolume.size }} 
+  storageClassName: {{ .Values.dataVolume.storageClassName }}
+{{- end -}}

--- a/k8s/templates/jmeter-master-deployment.yaml
+++ b/k8s/templates/jmeter-master-deployment.yaml
@@ -30,3 +30,22 @@ spec:
           args: ["master"]
           ports:
             - containerPort: 60000
+          volumeMounts:
+            - name: user-properties
+              mountPath: /jmeter/bin/user.properties
+              readOnly: true
+              subPath: "user.properties"
+            - name: data
+              mountPath: /jmeter/data
+              subPath: "data"
+      volumes:
+        - name:  user-properties
+          configMap:
+            name: {{ .Release.Name }}-user-properties
+        - name: data
+          {{- if .Values.dataVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data
+          {{ else }}
+          emptyDir: {}
+          {{ end }}

--- a/k8s/templates/jmeter-server-deployment.yaml
+++ b/k8s/templates/jmeter-server-deployment.yaml
@@ -31,3 +31,22 @@ spec:
           ports:
             - containerPort: 50000
             - containerPort: 1099
+          volumeMounts:
+            - name: user-properties
+              mountPath: /jmeter/bin/user.properties
+              readOnly: true
+              subPath: "user.properties"
+            - name: data
+              mountPath: /jmeter/data
+              subPath: "data"
+      volumes:
+        - name:  user-properties
+          configMap:
+            name: {{ .Release.Name }}-user-properties
+        - name: data
+          {{- if .Values.dataVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data
+          {{ else }}
+          emptyDir: {}
+          {{ end }}

--- a/k8s/templates/jmeter-user-properties.yaml
+++ b/k8s/templates/jmeter-user-properties.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: {{ .Release.Name }}-user-properties
+    labels:
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+        app: {{ template "distributed-jmeter.name" . }}
+data:
+  user.properties: |-
+    jmeter.save.saveservice.default_delimiter=\t
+    jmeter.save.saveservice.print_field_names=true

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -22,3 +22,8 @@ image:
   ## The tag for the image
   ## ref: https://hub.docker.com/r/pedrocesarti/jmeter-docker/tags/
   tag: 3.3
+
+dataVolume:
+  enabled: true
+  storageClassName: readwritemany 
+  size: 100Mi


### PR DESCRIPTION
Found that running distributed tests in a K8s cluster were not working for me, since the CSV files were not distributed to all servers. Also found a limitation in that the user.properties were not editable.

This pull-request adds a volume which is mounted on all pods to make sure testdata is available on all servers after copying to the master.
example to copy data to all pods: `kubectl cp sample.csv $MASTER_NAME:/jmeter/data --namespace jmeter`
